### PR TITLE
Implement jitsi meeting scraper

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -34,10 +34,11 @@ var runCmd = &cobra.Command{
 
 		var scrape_func = scrape.GetParticipantsZoom
 		if !manual {
-			if strings.Contains(url, "zoom") {
-				scrape_func = scrape.GetParticipantsZoom
-			} else if strings.Contains(url, "meet.jit.si") || force_jitsi {
+			// Checking optional force_jitsi flag first
+			if strings.Contains(url, "meet.jit.si") || force_jitsi {
 				scrape_func = scrape.GetParticipantsJitsi
+			} else if strings.Contains(url, "zoom") {
+				scrape_func = scrape.GetParticipantsZoom
 			} else {
 				return fmt.Errorf("Provided url does not contain known domain")
 			}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -49,7 +49,7 @@ var runCmd = &cobra.Command{
 			log.Info("Initializing TUI.")
 			url, err := cmd.Flags().GetString("url")
 			go func() {
-				err = scrape.GetParticipants(url, 1, &data, pw)
+				err = scrape.GetParticipantsZoom(url, 1, &data, pw)
 				if err != nil {
 					log.Fatal(err)
 				}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -22,7 +22,7 @@ var runCmd = &cobra.Command{
 			return err
 		}
 
-		force_jitsi, err := cmd.Flags().GetBool("jitsi")
+		forceJitsi, err := cmd.Flags().GetBool("jitsi")
 		if err != nil {
 			return err
 		}
@@ -32,14 +32,15 @@ var runCmd = &cobra.Command{
 			manual = true
 		}
 
-		var scrape_func = scrape.GetParticipantsZoom
+		var scraper scrape.Scraper
 		if !manual {
 			// Checking optional force_jitsi flag first
-			if strings.Contains(url, "meet.jit.si") || force_jitsi {
-				scrape_func = scrape.GetParticipantsJitsi
-			} else if strings.Contains(url, "zoom") {
-				scrape_func = scrape.GetParticipantsZoom
-			} else {
+			switch {
+			case forceJitsi || strings.Contains(url, "meet.jit.si"):
+				scraper = scrape.GetParticipantsJitsi
+			case strings.Contains(url, "zoom"):
+				scraper = scrape.GetParticipantsZoom
+			default:
 				return fmt.Errorf("Provided url does not contain known domain")
 			}
 		}
@@ -58,7 +59,7 @@ var runCmd = &cobra.Command{
 			log.Info("Initializing TUI.")
 			url, err := cmd.Flags().GetString("url")
 			go func() {
-				err = scrape_func(url, 1, &data, pw)
+				err = scraper(url, 1, &data, pw)
 				if err != nil {
 					log.Fatal(err)
 				}

--- a/internal/scrape/common.go
+++ b/internal/scrape/common.go
@@ -3,8 +3,12 @@ package scrape
 import (
 	"fmt"
 
+	"github.com/syncfast/clockwise/internal/tui"
 	"github.com/mxschmitt/playwright-go"
 )
+
+// Function prototype for per-platform participant count scraping
+type Scraper func(url string, refreshInterval int, data *tui.Data, pw *playwright.Playwright) error
 
 // initializePlaywright starts playwright in a standalone function to circumvent
 // some flaws in the upstream in terms of how it prints logs.

--- a/internal/scrape/jitsi.go
+++ b/internal/scrape/jitsi.go
@@ -1,0 +1,84 @@
+package scrape
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+	"regexp"
+
+	"github.com/mxschmitt/playwright-go"
+	"github.com/syncfast/clockwise/internal/tui"
+)
+
+// getParticipants retrieves the total participant count from a specified Jitsi
+// URL. It runs in a loop and updates the passed in `Data` struct every
+// `refreshInterval` seconds.
+func GetParticipants(url string, refreshInterval int, data *tui.Data, pw *playwright.Playwright) error {
+	var timeout float64 = 5000
+
+	browser, err := pw.Chromium.Launch()
+	if err != nil {
+		return fmt.Errorf("could not launch browser: %w", err)
+	}
+
+	page, err := browser.NewPage()
+	if err != nil {
+		return fmt.Errorf("could not create page: %w", err)
+	}
+
+	if _, err = page.Goto(url, playwright.PageGotoOptions{
+		WaitUntil: playwright.WaitUntilStateLoad,
+	}); err != nil {
+		return fmt.Errorf("could not goto: %w", err)
+	}
+
+	selector := "#Prejoin-input-field-id"
+	if err := page.Fill(selector, "clockwise-bot", playwright.FrameFillOptions{
+		Timeout: &timeout,
+	}); err != nil {
+		return err
+	}
+
+	// Wait for and click Join button
+	page.WaitForSelector("#lobby-screen > div.content > div.prejoin-input-area-container > div > div > div")
+
+	if err := page.Click("#lobby-screen > div.content > div.prejoin-input-area-container > div > div > div", playwright.PageClickOptions{
+		Timeout: &timeout,
+	}); err != nil {
+		return err
+	}
+
+	// Wait for and click participants sidebar
+	page.WaitForSelector("#new-toolbox > div > div > div > div:nth-child(6)")
+	if err := page.Click("#new-toolbox > div > div > div > div:nth-child(6)", playwright.PageClickOptions{
+		Timeout: &timeout,
+	}); err != nil {
+		return err
+	}
+
+	page.WaitForSelector("#layout_wrapper > div.participants_pane > div")
+
+	for {
+		res, err := page.QuerySelector("#layout_wrapper > div.participants_pane > div")
+		if err != nil {
+			return err
+		}
+
+		span, err := res.InnerHTML()
+		if err != nil {
+			return err
+		}
+
+		re := regexp.MustCompile(`Meeting participants \(([0-9]+)\)`)
+		match_str := re.FindStringSubmatch(span)
+
+		count, err := strconv.Atoi(match_str[1])
+		if err != nil {
+			return err
+		}
+
+		data.SetCount(count - 1)
+
+		time.Sleep(time.Second * time.Duration(refreshInterval))
+	}
+}

--- a/internal/scrape/jitsi.go
+++ b/internal/scrape/jitsi.go
@@ -13,7 +13,7 @@ import (
 // getParticipants retrieves the total participant count from a specified Jitsi
 // URL. It runs in a loop and updates the passed in `Data` struct every
 // `refreshInterval` seconds.
-func GetParticipants(url string, refreshInterval int, data *tui.Data, pw *playwright.Playwright) error {
+func GetParticipantsJitsi(url string, refreshInterval int, data *tui.Data, pw *playwright.Playwright) error {
 	var timeout float64 = 5000
 
 	browser, err := pw.Chromium.Launch()

--- a/internal/scrape/jitsi.go
+++ b/internal/scrape/jitsi.go
@@ -10,8 +10,8 @@ import (
 	"github.com/syncfast/clockwise/internal/tui"
 )
 
-// getParticipants retrieves the total participant count from a specified Jitsi
-// URL. It runs in a loop and updates the passed in `Data` struct every
+// GetParticipantsJitsi retrieves the total participant count from a specified
+// Jitsi URL. It runs in a loop and updates the passed in `Data` struct every
 // `refreshInterval` seconds.
 func GetParticipantsJitsi(url string, refreshInterval int, data *tui.Data, pw *playwright.Playwright) error {
 	var timeout float64 = 5000

--- a/internal/scrape/zoom.go
+++ b/internal/scrape/zoom.go
@@ -10,8 +10,8 @@ import (
 	"github.com/syncfast/clockwise/internal/tui"
 )
 
-// getParticipants retrieves the total participant count from a specified zoom
-// URL. It runs in a loop and updates the passed in `Data` struct every
+// GetParticipantsZoom retrieves the total participant count from a specified
+// zoom URL. It runs in a loop and updates the passed in `Data` struct every
 // `refreshInterval` seconds.
 func GetParticipantsZoom(url string, refreshInterval int, data *tui.Data, pw *playwright.Playwright) error {
 	if strings.Contains(url, "zoom.us/my/") {

--- a/internal/scrape/zoom.go
+++ b/internal/scrape/zoom.go
@@ -13,7 +13,7 @@ import (
 // getParticipants retrieves the total participant count from a specified zoom
 // URL. It runs in a loop and updates the passed in `Data` struct every
 // `refreshInterval` seconds.
-func GetParticipants(url string, refreshInterval int, data *tui.Data, pw *playwright.Playwright) error {
+func GetParticipantsZoom(url string, refreshInterval int, data *tui.Data, pw *playwright.Playwright) error {
 	if strings.Contains(url, "zoom.us/my/") {
 		return fmt.Errorf(`Error: clockwise is not compatible with Zoom Personal Meeting IDs at the moment.
 Disabling your PMI is as as simple as clicking a checkbox.


### PR DESCRIPTION
This just implements the jitsi meeting scraper, want to leave the front facing CLI implementation to the author.

Problem with Jitsi is: It can be self-hosted on arbitrary URLs, official one being `https://meet.jit.si/` - but it could be anything.

Maybe `--url` parameter could be renamed to `--zoom`, then additional services have `--jitsi` / `--teams` etc. ?
Just an idea.